### PR TITLE
Fix line wrap in code blocks

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -8,6 +8,7 @@ pre.highlight,
   padding: 10px;
 }
 
+pre.highlight code,
 .highlight pre code {
   white-space: pre-wrap;
 }


### PR DESCRIPTION
Line wrapping in highlighted code blocks doesn't work since the upgrade
to Jekyll 3.0 because the generated HTML changed a little bit with the
rouge syntax highliter. This simple fix to the CSS makes it work again.
