### PR TITLE
Fix mobile website initial width

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -2,10 +2,20 @@
 layout: null
 ---
 $(document).ready(function () {
+  const WIDTH_TRESHOLD = 960
+  function setInitialPanelState() {
+    currentWidth = $('.panel-cover').width()
+    if (currentWidth < WIDTH_TRESHOLD) {
+      $('.panel-cover').addClass('panel-cover--collapsed')
+      $('.panel-cover__description').css('display', 'block')
+    }
+  }
+  setInitialPanelState();
+
   $('a.blog-button').click(function (e) {
     if ($('.panel-cover').hasClass('panel-cover--collapsed')) return
     currentWidth = $('.panel-cover').width()
-    if (currentWidth < 960) {
+    if (currentWidth < WIDTH_TRESHOLD) {
       $('.panel-cover').addClass('panel-cover--collapsed')
       $('.content-wrapper').addClass('animated slideInRight')
     } else {


### PR DESCRIPTION
> On mobile devices where width < 960, blog content was overlapped by panel-cover
and users were unable to see it, but were able to scroll the page.
Closes https://github.com/joshgerdes/jekyll-uno/issues/42

In my case, I've fixed this a bit differently than proposed solution in https://github.com/joshgerdes/jekyll-uno/issues/42. The idea is to use correct style for `panel-cover` when web page loads for the first time. On devices with width < 960, `panel-cover` is loaded with `panel-cover--collapsed` style by default. 

**Before fix:**
<img width="1440" alt="screen shot 2017-01-08 at 2 28 18 pm" src="https://cloud.githubusercontent.com/assets/3036347/21749775/1d38157a-d5b7-11e6-9f13-268edf58ca32.png">


**After fix:**
<img width="1440" alt="screen shot 2017-01-08 at 2 26 09 pm" src="https://cloud.githubusercontent.com/assets/3036347/21749766/f0e87370-d5b6-11e6-98f4-7ae00f0a76cb.png">
