### PR TITLE
Updated "gems" to "plugins"

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -39,5 +39,5 @@ kramdown:
   # do not replace newlines by <br>s
   hard_wrap: false
 
-gems: ['jekyll-paginate']
+plugins: ['jekyll-paginate']
 exclude: ['README.md', 'Gemfile', 'Gemfile.lock', 'screenshot.png']


### PR DESCRIPTION
I received the following warning when building:
Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly.