### PR TITLE
add docker-compose support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  jekyll:
+    image: jekyll/jekyll:latest
+    command: jekyll serve --watch --force_polling --verbose
+    ports:
+      - 4000:4000
+    volumes:
+      - .:/srv/jekyll


### PR DESCRIPTION
This PR will add docker-compose support.
No need to install _ruby_ or _jekyll_ locally. Use `docker-compose up` to start serving the page. Will auto-regenerate on changes.

> Server address: http://0.0.0.0:4000/jekyll-uno/

BR, Matthias