### PR TITLE
Extended social links list with Stack Overflow

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ author:
   facebook_username: joshgerdes
   github_username:  joshgerdes
   linkedin_username:  joshgerdes
+  stackoverflow_id: 611812
 
 defaults:
   -

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -67,6 +67,17 @@
               </li>
             {% endif %}
 
+            {% if site.author.stackoverflow_id %}
+              <!-- Stack Overflow -->
+              <li class="navigation__item">
+                <a href="https://stackoverflow.com/users//{{ site.author.stackoverflow_id }}?tab=profile" title="{{ site.author.stackoverflow_id }} on Stack Overflow" target="_blank">
+                  <i class="icon icon-social-stack-overflow"></i>
+                  <span class="label">Stack Overflow</span>
+                </a>
+              </li>
+            {% endif %}
+
+
             {% if site.author.email %}
               <!-- Email -->
               <li class="navigation__item">


### PR DESCRIPTION
Added yet another (optional) link to social portal: Stack Overflow. Redirects right to the profile page.