### PR TITLE
Prepare for bitrise.io samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 :bulb: This project is used as sample project for building Jekyll projects on [bitrise.io](https://bitrise.io/) and is originally based on [jekyll-uno](https://github.com/joshgerdes/jekyll-uno).
 
+**Prerequisites**
+- `ruby v2.3.3+` & `rubygems`
+- [bundler](https://bundler.io/) `v1.1+`
+
 ---
 
 Jekyll-Uno - a minimal, responsive theme for Jekyll based on the [Uno](https://github.com/daleanthony/Uno) theme for Ghost.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # jekyll-uno
 
+### Bitrise
+
+:bulb: This project is used as sample project for building Jekyll projects on [bitrise.io](https://bitrise.io/) and is originally based on [jekyll-uno](https://github.com/joshgerdes/jekyll-uno).
+
+---
+
 Jekyll-Uno - a minimal, responsive theme for Jekyll based on the [Uno](https://github.com/daleanthony/Uno) theme for Ghost.
 
 > :warning:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,0 +1,37 @@
+options:
+  jekyll:
+    config: jekyll-config
+configs:
+  jekyll:
+    jekyll-config: |
+      format_version: "6"
+      default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+      project_type: jekyll
+      trigger_map:
+      - push_branch: '*'
+        workflow: primary
+      - pull_request_source_branch: '*'
+        workflow: primary
+      workflows:
+        primary:
+          steps:
+          - activate-ssh-key@4.0.3:
+              run_if: '{{getenv "SSH_RSA_PRIVATE_KEY" | ne ""}}'
+          - git-clone@4.0.13: {}
+          - cache-pull@2.0.1: {}
+          - script@1.1.5:
+              title: Do anything with Script step
+          - script@1.1.5:
+              title: Install dependencies & build
+              inputs:
+              - content: |
+                  #!/usr/bin/env bash
+                  # fail if any commands fails
+                  set -e
+                  # debug log
+                  set -x
+                  bundle install && bundle exec jekyll build
+          - deploy-to-bitrise-io@1.3.18: {}
+          - cache-push@2.0.5: {}
+warnings:
+  jekyll: []


### PR DESCRIPTION
### What has been done
Prepared the project for https://github.com/bitrise-core/bitrise-init/pull/116. It's required for this project to be moved to https://github.com/bitrise-samples organization.