### PR TITLE
Disable Scrollbars on Landing Page

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -5,6 +5,7 @@ sitemap:
 ---
 
 $(document).ready(function () {
+	$("body").css("overflow", "hidden");
   $('a.blog-button').click(function (e) {
     if ($('.panel-cover').hasClass('panel-cover--collapsed')) return
     currentWidth = $('.panel-cover').width()
@@ -15,14 +16,17 @@ $(document).ready(function () {
       $('.panel-cover').css('max-width', currentWidth)
       $('.panel-cover').animate({'max-width': '530px', 'width': '40%'}, 400, swing = 'swing', function () {})
     }
+	$("body").css("overflow", "auto");
   })
 
   if (window.location.hash && window.location.hash == '#blog') {
     $('.panel-cover').addClass('panel-cover--collapsed')
+	$("body").css("overflow", "auto");
   }
 
   if (window.location.pathname !== '{{ site.baseurl }}/' && window.location.pathname !== '{{ site.baseurl }}/index.html') {
     $('.panel-cover').addClass('panel-cover--collapsed')
+	$("body").css("overflow", "auto");
   }
 
   $('.btn-mobile-menu').click(function () {


### PR DESCRIPTION
The scrollbars of the blog posts are always visible, even when the posts are hidden. This fixes that.

BR Matthias

edit: Be aware, with this "hacky" solution the scroll bars will never be visible on the front page, regardless of its content length!