### PR TITLE
fix: text inside code block is no longer overflowing.

### DIFF
--- a/_sass/uno.scss
+++ b/_sass/uno.scss
@@ -1034,8 +1034,10 @@ pre {
 	font-family: Consolas, Menlo, Monaco, Lucida Console, Liberation Mono, DejaVu Sans Mono, Bitstream Vera Sans Mono, Courier New, monospace, serif;
 	font-size: .9em;
 	font-weight: normal;
-	line-height: 1.3em; }
-	pre code {
+	line-height: 1.3em;
+	word-wrap: break-word; }
+
+pre code {
 		padding: 0;
 		background: none;
 		border: none; }


### PR DESCRIPTION
Typically useful for long text inside `code` block.
In my case:
\```bash
long text ...SNIP...
\```

will overflowed outisde the `code` block.

**Quick fix, quick win!**