### PR TITLE
style: use of all remaining space for content block.

### DIFF
--- a/_sass/uno.scss
+++ b/_sass/uno.scss
@@ -1098,8 +1098,6 @@ pre {
 
 .content-wrapper {
 	z-index: 800;
-	width: 60%;
-	max-width: 800px;
 	margin-left: 40%; }
 
 .content-wrapper__inner {


### PR DESCRIPTION
Nowadays we use wide screens. So why not use them to the full?

As a picture is worth a thousand words...
Before:
<img width="1754" alt="Screenshot 2024-05-18 at 16 57 44" src="https://github.com/joshgerdes/jekyll-uno/assets/59340663/cd6f43cd-ea98-466f-9985-3b355c674ecb">

After:
<img width="1770" alt="Screenshot 2024-05-18 at 16 57 55" src="https://github.com/joshgerdes/jekyll-uno/assets/59340663/7c9c9db5-a6fc-433e-ad37-1fc7864fa1d9">
